### PR TITLE
update to latest libprosic release and bump prosic2 version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "prosic"
-version = "2.2.0-alpha0"
+version = "2.2.2"
 authors = ["Johannes Köster <johannes.koester@tu-dortmund.de>"]
 
 [dependencies]
-libprosic = "0.7.1"
+libprosic = "0.7.3"
 clap = {version = "2.24", features = ["yaml", "color", "suggestions"]}
 rust-htslib = "0.22"
 bio = "0.24"


### PR DESCRIPTION
The previous release does not contain the correct version number in the `Cargo.toml`. While at it, I also updated to the latest `libprosic` version I found -- installs and tests successfully on my machine.